### PR TITLE
Fixed: the Makefile now creates a build directory and also copies the resources of the data directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
-livius-bin:
-	( cd base && qmake && make ) && ( cd gui && qmake && make ) && ( cd livius && qmake && make ) && cp livius/livius livius-bin
+all:
+	( cd base && qmake && make ) && ( cd gui && qmake && make ) && ( cd livius && qmake && make ) && /bin/rm -rf build && mkdir -p build && cp livius/livius build && cp -R livius/data build && echo && echo "Build successful (the binary is located in the 'build' directory)"


### PR DESCRIPTION
Otherwise, the created binary could be started but as the
images where not found. Thus the board was empty.
