### PR TITLE
Changed layout

### DIFF
--- a/livius/liveframe.cpp
+++ b/livius/liveframe.cpp
@@ -63,26 +63,42 @@ LiveFrame::LiveFrame(QWidget *parent, PieceSet *pset, const QString &nick, const
 
 	board->setPieceSet( pset );
 
-	splitter = new QSplitter( Qt::Vertical, this );
-	hsplitter = new QSplitter( Qt::Horizontal, splitter );
-	hsplitter->addWidget( board );
+	splitter = new QSplitter( Qt::Horizontal, this );
+	hsplitter = new QSplitter( Qt::Vertical, splitter );
 	hsplitter->addWidget( info );
-
-	QList<int> sizes;
-	if ( !boardWidth || !infoWidth )
-		sizes << 2 << 1;
-	else
-		sizes << boardWidth << infoWidth;
-	QList<int> vsizes;
-	if ( !topHeight || !bottomHeight )
-		vsizes << 1 << 1;
-	else
-		vsizes << topHeight << bottomHeight;
-
-	hsplitter->setSizes( sizes );
+	hsplitter->addWidget( chat );
+	
+	splitter->addWidget( board );
 	splitter->addWidget( hsplitter );
-	splitter->addWidget( chat );
-	splitter->setSizes(vsizes);
+
+
+
+	if (!boardWidth || !infoWidth )
+	{
+		splitter->setStretchFactor( 0, 20 );
+		splitter->setStretchFactor( 1, 5 );
+	}
+	else
+	{
+		QList<int> sizes;
+		sizes << boardWidth << infoWidth;
+		splitter->setSizes( sizes );
+	}
+
+	if (!topHeight || !bottomHeight )
+	{
+		hsplitter->setStretchFactor( 0, 1 );
+		hsplitter->setStretchFactor( 1, 2 );
+	}
+	else
+	{
+		QList<int> vsizes;
+		vsizes << topHeight << bottomHeight;
+		hsplitter->setSizes( vsizes );
+	}
+
+
+
 	splitter->show();
 	update();
 
@@ -797,12 +813,12 @@ void LiveFrame::updateConfig()
 	if ( !splitter )
 		return;    
 	QList <int> sizes = splitter->sizes();
-	topHeight    = sizes[0];
-	bottomHeight = sizes[1];
+	boardWidth = sizes[0];
+	infoWidth = sizes[1];
 
 	if ( !hsplitter )
 		return;
 	sizes = hsplitter->sizes();
-	boardWidth = sizes[0];
-	infoWidth  = sizes[1];
+	topHeight = sizes[0];
+	bottomHeight  = sizes[1];
 }


### PR DESCRIPTION
This pull request changes the layout such that the chess board is bigger and doesn't have the chat window beneath it. Instead, the chat window is now fully below the info window.
![livius_commit](https://user-images.githubusercontent.com/17938103/126917602-721863af-0d24-44f6-9a29-8eef0eba65e6.jpeg)

I know this can be a subjective topic, but I believe that this version is better than the current one, because you can see the chess board better, and you need to scroll less to read earlier comments, as most comments didn't use the full width of the comment window in the current version anyway.